### PR TITLE
定期実行もしくは fail したときに通知するように

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-      - uses: hmarr/debug-action@v2
       - uses: microsoft/playwright-github-action@v1
 
       - name: Get yarn cache directory path

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,7 +2,7 @@ on:
   push:
   schedule:
     # JST で毎週土曜 12:00 (UTC で毎週土曜 3:00) に実行
-    - cron: '*/10 * * * *'
+    - cron: '0 3 * * SAT'
 
 jobs:
   build:
@@ -38,4 +38,4 @@ jobs:
           fields: repo,message,commit,job,took
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()
+        if: ${{ failure() || (github.event_name == 'schedule' && always()) }}


### PR DESCRIPTION
ref: #20 
- push した時は success で通知するとノイズになるので、failure の時だけ通知したい
- schedule の時は success でも failure でも通知したい