### PR TITLE
Safari で IME の確定時にアイコンが挿入されてしまう問題を修正

### DIFF
--- a/src/components/PopupMenu.tsx
+++ b/src/components/PopupMenu.tsx
@@ -52,7 +52,7 @@ export function PopupMenu({
       // 閉じている時は何もしない
       if (!open) return;
       // IMEによる変換中は何もしない
-      if (e.isComposing) return;
+      if (e.isComposing || (e.key === 'Enter' && e.which === 229)) return;
 
       const isTab = e.key === 'Tab' && !e.ctrlKey && !e.shiftKey && !e.altKey;
       const isShiftTab = e.key === 'Tab' && !e.ctrlKey && e.shiftKey && !e.altKey;


### PR DESCRIPTION
close: #64 

## 動作確認
- [x] Chrome for MacOSX
- [x] Firefox for MacOSX
- [x] Safari for MacOSX