### PR TITLE
Fuzzy Match の曖昧度のしきい値を変更

### DIFF
--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -7,9 +7,9 @@ import { uniqBy } from './collection';
  * 曖昧検索で `items` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
 export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
-  // query の長さが 0〜3 ならは 0 文字まで、4〜7 なら 1 文字まで、
-  // 8〜11 ならは2 文字まで、12 以上なら 3 文字まで誤字を許容する
-  const maxAambig = Math.min(Math.floor(query.length / 4), 3);
+  // query の長さが 0〜2 ならは 0 文字まで、3〜5 なら 1 文字まで、
+  // 6〜8 ならは 2 文字まで、9 以上なら 3 文字まで誤字を許容する
+  const maxAambig = Math.min(Math.floor(query.length / 3), 3);
   const match = Asearch(` ${query} `); // 部分一致できるように、両端をスペースで囲む
   // あいまい度の少ない項目から順に並べる
   const newItems: Item<T>[] = [];

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -7,8 +7,8 @@ import { uniqBy } from './collection';
  * 曖昧検索で `items` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
 export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
-  // query の長さが 1〜3文字までは 0 文字まで、4〜7文字までは 1 文字まで、
-  // 8〜11文字までは 2 文字まで、12文字以降は 3 文字まで誤字を許容する
+  // query の長さが 0〜3 ならは 0 文字まで、4〜7 なら 1 文字まで、
+  // 8〜11 ならは2 文字まで、12 以上なら 3 文字まで誤字を許容する
   const maxAambig = Math.min(Math.floor(query.length / 4), 3);
   const match = Asearch(` ${query} `); // 部分一致できるように、両端をスペースで囲む
   // あいまい度の少ない項目から順に並べる

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -7,8 +7,8 @@ import { uniqBy } from './collection';
  * 曖昧検索で `items` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
 export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
-  // query の長さが 0〜2 ならは 0 文字まで、3〜5 なら 1 文字まで、
-  // 6〜8 ならは 2 文字まで、9 以上なら 3 文字まで誤字を許容する
+  // query の長さが 0〜2 なら 0 文字まで、3〜5 なら 1 文字まで、
+  // 6〜8 なら 2 文字まで、9 以上なら 3 文字まで誤字を許容する
   const maxAambig = Math.min(Math.floor(query.length / 3), 3);
   const match = Asearch(` ${query} `); // 部分一致できるように、両端をスペースで囲む
   // あいまい度の少ない項目から順に並べる

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -7,10 +7,11 @@ import { uniqBy } from './collection';
  * 曖昧検索で `items` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
 export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
-  const maxAambig = Math.min(Math.floor(query.length / 4) + 1, 3);
+  // query の長さが 1〜3文字までは 0 文字まで、4〜7文字までは 1 文字まで、
+  // 8〜11文字までは 2 文字まで、12文字以降は 3 文字まで誤字を許容する
+  const maxAambig = Math.min(Math.floor(query.length / 4), 3);
   const match = Asearch(` ${query} `); // 部分一致できるように、両端をスペースで囲む
-  // あいまい度の少ない項目から順に並べる
-  // 重複は除く
+  // あいまい度の少ない項目から順に並べる (ただし重複は除く)
   const pushedItems: Set<Item<T>> = new Set();
   const result: Item<T>[] = [];
   for (let ambig = 0; ambig <= maxAambig; ambig++) {

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -11,19 +11,16 @@ export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
   // 8〜11文字までは 2 文字まで、12文字以降は 3 文字まで誤字を許容する
   const maxAambig = Math.min(Math.floor(query.length / 4), 3);
   const match = Asearch(` ${query} `); // 部分一致できるように、両端をスペースで囲む
-  // あいまい度の少ない項目から順に並べる (ただし重複は除く)
-  const pushedItems: Set<Item<T>> = new Set();
-  const result: Item<T>[] = [];
+  // あいまい度の少ない項目から順に並べる
+  const newItems: Item<T>[] = [];
   for (let ambig = 0; ambig <= maxAambig; ambig++) {
-    items.forEach((item) => {
-      if (!match(item.searchableText, ambig)) return;
-      if (pushedItems.has(item)) return;
-      pushedItems.add(item);
-      result.push(item);
-    });
+    for (const item of items) {
+      if (match(item.searchableText, ambig)) newItems.push(item);
+    }
   }
-
-  return result;
+  // 重複は除く
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return uniqBy(newItems, (item) => item.key);
 }
 
 /**

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { App as NativeApp, AppProps } from '../../src/components/App';
 import { ScrapboxContext } from '../../src/contexts/ScrapboxContext';
 import { Icon } from '../../src/lib/icon';
+import { startsWithMatcher } from '../../src/lib/matcher';
 import { createEditor, createScrapboxAPI } from '../helpers/html';
 import { keydownAEvent, keydownCtrlLEvent, keydownEnterEvent, keydownEscapeEvent } from '../helpers/key';
 
@@ -21,21 +22,22 @@ jest.mock('../../src/lib/scrapbox', () => {
 type Options = { embeddedIcons?: Icon[] };
 function App(props: AppProps & Options) {
   const presetIcons: Icon[] = props.presetIcons ?? [
-    new Icon('project', 'bbbbb'),
-    new Icon('project', 'ccccc'),
-    new Icon('project', 'ccccc'),
+    new Icon('project', 'b'),
+    new Icon('project', 'c'),
+    new Icon('project', 'c'),
   ];
   const editor = createEditor({
     embeddedIcons: props.embeddedIcons ?? [
-      new Icon('project', 'aaaaa'),
-      new Icon('project', 'aaaaa'),
-      new Icon('project', 'bbbbb'),
+      new Icon('project', 'a'),
+      new Icon('project', 'a'),
+      new Icon('project', 'b'),
     ],
   });
   const scrapbox = createScrapboxAPI();
+  const matcher = startsWithMatcher;
   return (
     <ScrapboxContext.Provider value={{ editor, scrapbox }}>
-      <NativeApp presetIcons={presetIcons} {...props} />
+      <NativeApp presetIcons={presetIcons} matcher={matcher} {...props} />
     </ScrapboxContext.Provider>
   );
 }
@@ -100,29 +102,29 @@ describe('App', () => {
         const buttonContainer = getByTestId('button-container');
         const queryInput = getByTestId('query-input');
 
-        expect(buttonContainer.childElementCount).toEqual(2); // aaaaa, bbbbb の 2アイコンが表示される
-        userEvent.type(queryInput, 'bbbbb');
-        expect(buttonContainer.childElementCount).toEqual(1); // bbbbb だけ表示される
+        expect(buttonContainer.childElementCount).toEqual(2); // a, b の 2アイコンが表示される
+        userEvent.type(queryInput, 'b');
+        expect(buttonContainer.childElementCount).toEqual(1); // b だけ表示される
         await act(() => {
           fireEvent(document, keydownEnterEvent);
         });
-        expect(mockInsertText).toBeCalledWith(expect.anything(), '[bbbbb.icon]');
+        expect(mockInsertText).toBeCalledWith(expect.anything(), '[b.icon]');
       });
     });
     test('isSuggestionOpenKeyDown が真になるようなキーを押下したら、presetIcons が suggest される', async () => {
       const { getByTestId } = await renderApp({});
       const buttonContainer = getByTestId('button-container');
 
-      expect(buttonContainer.childElementCount).toEqual(2); // aaaaa, bbbbb の 2アイコンが表示される
+      expect(buttonContainer.childElementCount).toEqual(2); // a, b の 2アイコンが表示される
       await act(() => {
         fireEvent(document, keydownCtrlLEvent);
       });
-      expect(buttonContainer.childElementCount).toEqual(3); // aaaaa, bbbbb, cccc の 3アイコンが表示される
+      expect(buttonContainer.childElementCount).toEqual(3); // a, b, cccc の 3アイコンが表示される
     });
     test('defaultSuggestPresetIcons が真なら最初からプリセットアイコンが suggest される', async () => {
       const { getByTestId } = await renderApp({ defaultSuggestPresetIcons: true });
       const buttonContainer = getByTestId('button-container');
-      expect(buttonContainer.childElementCount).toEqual(3); // aaaaa, bbbbb, ccccc の 3アイコンが表示される
+      expect(buttonContainer.childElementCount).toEqual(3); // a, b, c の 3アイコンが表示される
     });
     test('同名のページタイトルのアイコンが suggest されている場合は、括弧付きでプロジェクト名が表示される', async () => {
       const { queryAllByTestId } = await renderApp({

--- a/test/components/SuggestBox.test.tsx
+++ b/test/components/SuggestBox.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { datatype } from 'faker';
 import { SuggestionBox } from '../../src/components/SuggestionBox';
+import { startsWithMatcher } from '../../src/lib/matcher';
 import { CursorPosition } from '../../src/types';
 import { keydownEnterEvent, keydownEscapeEvent } from '../helpers/key';
 
@@ -13,7 +14,8 @@ const items = [
   { key: 3, element: <span key="3">abc</span>, searchableText: 'abc', value: 'abc' },
   { key: 4, element: <span key="4">z</span>, searchableText: 'z', value: 'z' },
 ];
-const props = { cursorPosition, items };
+const matcher = startsWithMatcher;
+const props = { cursorPosition, items, matcher };
 
 describe('SuggestionBox', () => {
   describe('open === false の時', () => {
@@ -64,13 +66,13 @@ describe('SuggestionBox', () => {
 
         expect(buttonContainer.childElementCount).toEqual(4);
         userEvent.type(queryInput, 'a');
-        expect(buttonContainer.childElementCount).toEqual(4);
-        userEvent.type(queryInput, 'b');
         expect(buttonContainer.childElementCount).toEqual(3);
+        userEvent.type(queryInput, 'b');
+        expect(buttonContainer.childElementCount).toEqual(2);
         userEvent.type(queryInput, 'c');
-        expect(buttonContainer.childElementCount).toEqual(2);
+        expect(buttonContainer.childElementCount).toEqual(1);
         userEvent.type(queryInput, 'd');
-        expect(buttonContainer.childElementCount).toEqual(2);
+        expect(buttonContainer.childElementCount).toEqual(0);
       });
       test('Enter 押下で onSelect が呼び出される', async () => {
         const onSelect = jest.fn();

--- a/test/components/__snapshots__/App.test.tsx.snap
+++ b/test/components/__snapshots__/App.test.tsx.snap
@@ -24,16 +24,16 @@ exports[`App 初期状態 isSuggestionOpenKeyDown が真になるようなキー
         >
           <span>
             <img
-              alt="aaaaa"
-              src="/api/pages/project/aaaaa/icon"
+              alt="a"
+              src="/api/pages/project/a/icon"
               style="width: 1.3em; height: 1.3em; object-fit: contain;"
-              title="aaaaa"
+              title="a"
             />
              
             <span
               data-testid="suggested-icon-label"
             >
-              aaaaa
+              a
             </span>
           </span>
         </div>
@@ -42,16 +42,16 @@ exports[`App 初期状態 isSuggestionOpenKeyDown が真になるようなキー
         >
           <span>
             <img
-              alt="bbbbb"
-              src="/api/pages/project/bbbbb/icon"
+              alt="b"
+              src="/api/pages/project/b/icon"
               style="width: 1.3em; height: 1.3em; object-fit: contain;"
-              title="bbbbb"
+              title="b"
             />
              
             <span
               data-testid="suggested-icon-label"
             >
-              bbbbb
+              b
             </span>
           </span>
         </div>

--- a/test/lib/matcher.test.ts
+++ b/test/lib/matcher.test.ts
@@ -2,62 +2,62 @@ import { combinedMatcher, fuzzyMatcher, includesMatcher, startsWithMatcher } fro
 
 describe('fuzzyMatcher', () => {
   describe('query に曖昧一致する items のみが返る', () => {
-    test('query の長さが 0〜3 なら 1 文字も誤字を許容しない', () => {
+    test('query の長さが 0〜2 なら 1 文字も誤字を許容しない', () => {
+      expect(
+        fuzzyMatcher('aa', [
+          // マッチする
+          { key: 0, element: '', searchableText: 'aa', value: '' },
+          // マッチしない
+          { key: 1, element: '', searchableText: 'ab', value: '' },
+        ]),
+      ).toStrictEqual([{ key: 0, element: '', searchableText: 'aa', value: '' }]);
+    });
+    test('query の長さが 3〜5 なら 1 文字まで誤字を許容する', () => {
       expect(
         fuzzyMatcher('aaa', [
           // マッチする
           { key: 0, element: '', searchableText: 'aaa', value: '' },
-          // マッチしない
           { key: 1, element: '', searchableText: 'aab', value: '' },
-        ]),
-      ).toStrictEqual([{ key: 0, element: '', searchableText: 'aaa', value: '' }]);
-    });
-    test('query の長さが 4〜7 なら 1 文字まで誤字を許容する', () => {
-      expect(
-        fuzzyMatcher('aaaa', [
-          // マッチする
-          { key: 0, element: '', searchableText: 'aaaa', value: '' },
-          { key: 1, element: '', searchableText: 'aaab', value: '' },
           // マッチしない
-          { key: 2, element: '', searchableText: 'aabb', value: '' },
+          { key: 2, element: '', searchableText: 'abb', value: '' },
         ]),
       ).toStrictEqual([
-        { key: 0, element: '', searchableText: 'aaaa', value: '' },
-        { key: 1, element: '', searchableText: 'aaab', value: '' },
+        { key: 0, element: '', searchableText: 'aaa', value: '' },
+        { key: 1, element: '', searchableText: 'aab', value: '' },
       ]);
     });
-    test('query の長さが 8〜11 なら 2 文字まで誤字を許容する', () => {
+    test('query の長さが 6〜8 なら 2 文字まで誤字を許容する', () => {
       expect(
-        fuzzyMatcher('aaaaaaaa', [
+        fuzzyMatcher('aaaaaa', [
           // マッチする
-          { key: 0, element: '', searchableText: 'aaaaaaaa', value: '' },
-          { key: 1, element: '', searchableText: 'aaaaaaab', value: '' },
-          { key: 2, element: '', searchableText: 'aaaaaabb', value: '' },
+          { key: 0, element: '', searchableText: 'aaaaaa', value: '' },
+          { key: 1, element: '', searchableText: 'aaaaab', value: '' },
+          { key: 2, element: '', searchableText: 'aaaabb', value: '' },
           // マッチしない
-          { key: 3, element: '', searchableText: 'aaaaabbb', value: '' },
+          { key: 3, element: '', searchableText: 'aaabbb', value: '' },
         ]),
       ).toStrictEqual([
-        { key: 0, element: '', searchableText: 'aaaaaaaa', value: '' },
-        { key: 1, element: '', searchableText: 'aaaaaaab', value: '' },
-        { key: 2, element: '', searchableText: 'aaaaaabb', value: '' },
+        { key: 0, element: '', searchableText: 'aaaaaa', value: '' },
+        { key: 1, element: '', searchableText: 'aaaaab', value: '' },
+        { key: 2, element: '', searchableText: 'aaaabb', value: '' },
       ]);
     });
-    test('query の長さが 12 以上なら 3 文字まで誤字を許容する', () => {
+    test('query の長さが 9 以上なら 3 文字まで誤字を許容する', () => {
       expect(
-        fuzzyMatcher('aaaaaaaaaaaa', [
+        fuzzyMatcher('aaaaaaaaa', [
           // マッチする
-          { key: 0, element: '', searchableText: 'aaaaaaaaaaaa', value: '' },
-          { key: 1, element: '', searchableText: 'aaaaaaaaaaab', value: '' },
-          { key: 2, element: '', searchableText: 'aaaaaaaaaabb', value: '' },
-          { key: 3, element: '', searchableText: 'aaaaaaaaabbb', value: '' },
+          { key: 0, element: '', searchableText: 'aaaaaaaaa', value: '' },
+          { key: 1, element: '', searchableText: 'aaaaaaaab', value: '' },
+          { key: 2, element: '', searchableText: 'aaaaaaabb', value: '' },
+          { key: 3, element: '', searchableText: 'aaaaaabbb', value: '' },
           // マッチしない
-          { key: 4, element: '', searchableText: 'aaaaaaaabbbb', value: '' },
+          { key: 4, element: '', searchableText: 'aaaaabbbb', value: '' },
         ]),
       ).toStrictEqual([
-        { key: 0, element: '', searchableText: 'aaaaaaaaaaaa', value: '' },
-        { key: 1, element: '', searchableText: 'aaaaaaaaaaab', value: '' },
-        { key: 2, element: '', searchableText: 'aaaaaaaaaabb', value: '' },
-        { key: 3, element: '', searchableText: 'aaaaaaaaabbb', value: '' },
+        { key: 0, element: '', searchableText: 'aaaaaaaaa', value: '' },
+        { key: 1, element: '', searchableText: 'aaaaaaaab', value: '' },
+        { key: 2, element: '', searchableText: 'aaaaaaabb', value: '' },
+        { key: 3, element: '', searchableText: 'aaaaaabbb', value: '' },
       ]);
     });
   });

--- a/test/lib/matcher.test.ts
+++ b/test/lib/matcher.test.ts
@@ -1,31 +1,96 @@
 import { combinedMatcher, fuzzyMatcher, includesMatcher, startsWithMatcher } from '../../src/lib/matcher';
 
 describe('fuzzyMatcher', () => {
-  test('query にあいまい一致する items のみが返る', () => {
+  describe('query に曖昧一致する items のみが返る', () => {
+    test('query の長さが 0〜3 なら 1 文字も誤字を許容しない', () => {
+      expect(
+        fuzzyMatcher('aaa', [
+          // マッチする
+          { key: 0, element: '', searchableText: 'aaa', value: '' },
+          // マッチしない
+          { key: 1, element: '', searchableText: 'aab', value: '' },
+        ]),
+      ).toStrictEqual([{ key: 0, element: '', searchableText: 'aaa', value: '' }]);
+    });
+    test('query の長さが 4〜7 なら 1 文字まで誤字を許容する', () => {
+      expect(
+        fuzzyMatcher('aaaa', [
+          // マッチする
+          { key: 0, element: '', searchableText: 'aaaa', value: '' },
+          { key: 1, element: '', searchableText: 'aaab', value: '' },
+          // マッチしない
+          { key: 2, element: '', searchableText: 'aabb', value: '' },
+        ]),
+      ).toStrictEqual([
+        { key: 0, element: '', searchableText: 'aaaa', value: '' },
+        { key: 1, element: '', searchableText: 'aaab', value: '' },
+      ]);
+    });
+    test('query の長さが 8〜11 なら 2 文字まで誤字を許容する', () => {
+      expect(
+        fuzzyMatcher('aaaaaaaa', [
+          // マッチする
+          { key: 0, element: '', searchableText: 'aaaaaaaa', value: '' },
+          { key: 1, element: '', searchableText: 'aaaaaaab', value: '' },
+          { key: 2, element: '', searchableText: 'aaaaaabb', value: '' },
+          // マッチしない
+          { key: 3, element: '', searchableText: 'aaaaabbb', value: '' },
+        ]),
+      ).toStrictEqual([
+        { key: 0, element: '', searchableText: 'aaaaaaaa', value: '' },
+        { key: 1, element: '', searchableText: 'aaaaaaab', value: '' },
+        { key: 2, element: '', searchableText: 'aaaaaabb', value: '' },
+      ]);
+    });
+    test('query の長さが 12 以上なら 3 文字まで誤字を許容する', () => {
+      expect(
+        fuzzyMatcher('aaaaaaaaaaaa', [
+          // マッチする
+          { key: 0, element: '', searchableText: 'aaaaaaaaaaaa', value: '' },
+          { key: 1, element: '', searchableText: 'aaaaaaaaaaab', value: '' },
+          { key: 2, element: '', searchableText: 'aaaaaaaaaabb', value: '' },
+          { key: 3, element: '', searchableText: 'aaaaaaaaabbb', value: '' },
+          // マッチしない
+          { key: 4, element: '', searchableText: 'aaaaaaaabbbb', value: '' },
+        ]),
+      ).toStrictEqual([
+        { key: 0, element: '', searchableText: 'aaaaaaaaaaaa', value: '' },
+        { key: 1, element: '', searchableText: 'aaaaaaaaaaab', value: '' },
+        { key: 2, element: '', searchableText: 'aaaaaaaaaabb', value: '' },
+        { key: 3, element: '', searchableText: 'aaaaaaaaabbb', value: '' },
+      ]);
+    });
+  });
+  describe('曖昧度の昇順で返ってくる', () => {
     expect(
-      fuzzyMatcher('foo', [
-        // マッチする
-        { key: 0, element: '', searchableText: 'foo', value: '' },
-        { key: 1, element: '', searchableText: 'foo bar', value: '' },
-        { key: 2, element: '', searchableText: 'foo bar baz', value: '' },
-        { key: 3, element: '', searchableText: 'bar foo baz', value: '' },
-        { key: 4, element: '', searchableText: 'bar baz foo', value: '' },
-        { key: 5, element: '', searchableText: 'foo foo foo', value: '' },
-        { key: 6, element: '', searchableText: 'fo bar', value: '' },
-        { key: 7, element: '', searchableText: 'fo o bar', value: '' },
-        // マッチしない
-        { key: 8, element: '', searchableText: 'fee', value: '' },
-        { key: 9, element: '', searchableText: 'bar', value: '' },
+      fuzzyMatcher('aaaaaaaaaaaa', [
+        { key: 0, element: '', searchableText: 'aaaaaaaaabbb', value: '' },
+        { key: 1, element: '', searchableText: 'aaaaaaaaaccc', value: '' },
+        { key: 2, element: '', searchableText: 'aaaaaaaaaabb', value: '' },
+        { key: 3, element: '', searchableText: 'aaaaaaaaaacc', value: '' },
+        { key: 4, element: '', searchableText: 'aaaaaaaaaaab', value: '' },
+        { key: 5, element: '', searchableText: 'aaaaaaaaaaac', value: '' },
+        { key: 6, element: '', searchableText: 'aaaaaaaaaaaa', value: '' },
       ]),
     ).toStrictEqual([
-      { key: 0, element: '', searchableText: 'foo', value: '' },
-      { key: 1, element: '', searchableText: 'foo bar', value: '' },
-      { key: 2, element: '', searchableText: 'foo bar baz', value: '' },
-      { key: 3, element: '', searchableText: 'bar foo baz', value: '' },
-      { key: 4, element: '', searchableText: 'bar baz foo', value: '' },
-      { key: 5, element: '', searchableText: 'foo foo foo', value: '' },
-      { key: 6, element: '', searchableText: 'fo bar', value: '' },
-      { key: 7, element: '', searchableText: 'fo o bar', value: '' },
+      { key: 6, element: '', searchableText: 'aaaaaaaaaaaa', value: '' },
+      { key: 4, element: '', searchableText: 'aaaaaaaaaaab', value: '' },
+      { key: 5, element: '', searchableText: 'aaaaaaaaaaac', value: '' },
+      { key: 2, element: '', searchableText: 'aaaaaaaaaabb', value: '' },
+      { key: 3, element: '', searchableText: 'aaaaaaaaaacc', value: '' },
+      { key: 0, element: '', searchableText: 'aaaaaaaaabbb', value: '' },
+      { key: 1, element: '', searchableText: 'aaaaaaaaaccc', value: '' },
+    ]);
+  });
+  describe('部分一致する', () => {
+    expect(
+      fuzzyMatcher('foo', [
+        { key: 0, element: '', searchableText: 'foo bar', value: '' },
+        { key: 1, element: '', searchableText: 'bar foo baz', value: '' },
+      ]),
+    ).toStrictEqual([
+      { key: 0, element: '', searchableText: 'foo bar', value: '' },
+      { key: 1, element: '', searchableText: 'bar foo baz', value: '' },
     ]);
   });
   test('マッチは capital-insensitive', () => {
@@ -146,26 +211,26 @@ describe('includesMatcher', () => {
 describe('combinedMatcher', () => {
   test('前方一致 > 部分一致 > 曖昧検索 の順で並び替えられて返される', () => {
     expect(
-      combinedMatcher('foo', [
+      combinedMatcher('aaaa', [
         // 曖昧一致する
-        { key: 1, element: '', searchableText: 'fox bar', value: '' },
-        { key: 2, element: '', searchableText: 'zoo bar', value: '' },
+        { key: 1, element: '', searchableText: 'aaab', value: '' },
+        { key: 2, element: '', searchableText: 'aaac', value: '' },
         // 部分一致する
-        { key: 3, element: '', searchableText: 'bar foo baz', value: '' },
-        { key: 4, element: '', searchableText: 'bar baz foo', value: '' },
+        { key: 3, element: '', searchableText: 'bbbb aaaa cccc', value: '' },
+        { key: 4, element: '', searchableText: 'bbbb cccc aaaa', value: '' },
         // 前方一致する
-        { key: 5, element: '', searchableText: 'foo', value: '' },
-        { key: 6, element: '', searchableText: 'foo bar', value: '' },
+        { key: 5, element: '', searchableText: 'aaaa', value: '' },
+        { key: 6, element: '', searchableText: 'aaaa bbbb', value: '' },
         // マッチしない
         { key: 7, element: '', searchableText: 'mizdra', value: '' },
       ]),
     ).toStrictEqual([
-      { key: 5, element: '', searchableText: 'foo', value: '' },
-      { key: 6, element: '', searchableText: 'foo bar', value: '' },
-      { key: 3, element: '', searchableText: 'bar foo baz', value: '' },
-      { key: 4, element: '', searchableText: 'bar baz foo', value: '' },
-      { key: 1, element: '', searchableText: 'fox bar', value: '' },
-      { key: 2, element: '', searchableText: 'zoo bar', value: '' },
+      { key: 5, element: '', searchableText: 'aaaa', value: '' },
+      { key: 6, element: '', searchableText: 'aaaa bbbb', value: '' },
+      { key: 3, element: '', searchableText: 'bbbb aaaa cccc', value: '' },
+      { key: 4, element: '', searchableText: 'bbbb cccc aaaa', value: '' },
+      { key: 1, element: '', searchableText: 'aaab', value: '' },
+      { key: 2, element: '', searchableText: 'aaac', value: '' },
     ]);
   });
 });


### PR DESCRIPTION
ref: #76, #72 

https://github.com/mizdra/scrapbox-userscript-icon-suggestion/issues/76#issuecomment-919320974 のアイデアに基づいて改良する。

## Before
query の長さが 0〜3 ならは 1 文字まで、4〜7 なら 2 文字まで、8 以上 なら 3 文字まで誤字を許容する

## After
query の長さが 0〜2 ならは 0 文字まで、3〜5 なら 1 文字まで、6〜8 なら 2 文字まで、9 以上なら 3 文字まで誤字を許容する