### PR TITLE
組み込み matcher を実装

### DIFF
--- a/src/components/SuggestionBox.tsx
+++ b/src/components/SuggestionBox.tsx
@@ -1,7 +1,7 @@
 import { ComponentChild } from 'preact';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { JSXInternal } from 'preact/src/jsx';
-import { combinedMatcher } from '../lib/matcher';
+import { forwardPartialFuzzyMatcher } from '../lib/matcher';
 import { CursorPosition, Matcher } from '../types';
 import { PopupMenu } from './PopupMenu';
 import { QueryInput } from './SuggestionBox/QueryInput';
@@ -30,7 +30,7 @@ export function SuggestionBox<T>({
   emptyMessage,
   items,
   cursorPosition,
-  matcher = combinedMatcher,
+  matcher = forwardPartialFuzzyMatcher,
   onSelect,
   onSelectNonexistent,
   onClose,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { registerIconSuggestion } from './lib/register';
 export { Icon } from './lib/icon';
 export { fetchMemberPageIcons, fetchRelatedPageIconsByHashTag } from './lib/preset-icon';
-export { fuzzyMatcher, startsWithMatcher, includesMatcher, combinedMatcher } from './lib/matcher';
+export { fuzzyMatcher, forwardMatcher, partialMatcher, forwardPartialFuzzyMatcher } from './lib/matcher';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { registerIconSuggestion } from './lib/register';
 export { Icon } from './lib/icon';
 export { fetchMemberPageIcons, fetchRelatedPageIconsByHashTag } from './lib/preset-icon';
+export { fuzzyMatcher, startsWithMatcher, includesMatcher, combinedMatcher } from './lib/matcher';

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -3,8 +3,8 @@ import { Item } from '../types';
 import { uniqBy } from './collection';
 
 /**
- * 曖昧検索による matcher。
- * 曖昧検索で `items` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
+ * 曖昧一致による matcher。
+ * 曖昧一致で `items` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
 export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
   // query の長さが 0〜2 なら 0 文字まで、3〜5 なら 1 文字まで、
@@ -27,7 +27,7 @@ export function fuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
  * 前方一致による matcher。
  * 元の `items` の順序を維持しつつ、`items` を前方一致でフィルタして返す。
  * */
-export function startsWithMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
+export function forwardMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
   return items.filter((item) => item.searchableText.toLowerCase().startsWith(query.toLowerCase()));
 }
 
@@ -35,20 +35,16 @@ export function startsWithMatcher<T>(query: string, items: Item<T>[]): Item<T>[]
  * 部分一致による matcher。
  * 元の `items` の順序を維持しつつ、`items` を部分一致でフィルタして返す。
  * */
-export function includesMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
+export function partialMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
   return items.filter((item) => item.searchableText.toLowerCase().includes(query.toLowerCase()));
 }
 
 /**
- * 前方一致、部分一致、曖昧検索を組み合わせた matcher。
- * 前方一致 > 部分一致 > 曖昧検索 の順で fallback しながらフィルタしていき、残ったものを返す。
+ * 前方一致、部分一致、曖昧一致を組み合わせた matcher。
+ * 前方一致 > 部分一致 > 曖昧一致 の順で fallback しながらフィルタしていき、残ったものを返す。
  * */
-export function combinedMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
-  const newItems = [
-    ...startsWithMatcher(query, items),
-    ...includesMatcher(query, items),
-    ...fuzzyMatcher(query, items),
-  ];
+export function forwardPartialFuzzyMatcher<T>(query: string, items: Item<T>[]): Item<T>[] {
+  const newItems = [...forwardMatcher(query, items), ...partialMatcher(query, items), ...fuzzyMatcher(query, items)];
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return uniqBy(newItems, (item) => item.key);
 }

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { App as NativeApp, AppProps } from '../../src/components/App';
 import { ScrapboxContext } from '../../src/contexts/ScrapboxContext';
 import { Icon } from '../../src/lib/icon';
-import { startsWithMatcher } from '../../src/lib/matcher';
+import { forwardMatcher } from '../../src/lib/matcher';
 import { createEditor, createScrapboxAPI } from '../helpers/html';
 import { keydownAEvent, keydownCtrlLEvent, keydownEnterEvent, keydownEscapeEvent } from '../helpers/key';
 
@@ -34,7 +34,7 @@ function App(props: AppProps & Options) {
     ],
   });
   const scrapbox = createScrapboxAPI();
-  const matcher = startsWithMatcher;
+  const matcher = forwardMatcher;
   return (
     <ScrapboxContext.Provider value={{ editor, scrapbox }}>
       <NativeApp presetIcons={presetIcons} matcher={matcher} {...props} />

--- a/test/components/SuggestBox.test.tsx
+++ b/test/components/SuggestBox.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { datatype } from 'faker';
 import { SuggestionBox } from '../../src/components/SuggestionBox';
-import { startsWithMatcher } from '../../src/lib/matcher';
+import { forwardMatcher } from '../../src/lib/matcher';
 import { CursorPosition } from '../../src/types';
 import { keydownEnterEvent, keydownEscapeEvent } from '../helpers/key';
 
@@ -14,7 +14,7 @@ const items = [
   { key: 3, element: <span key="3">abc</span>, searchableText: 'abc', value: 'abc' },
   { key: 4, element: <span key="4">z</span>, searchableText: 'z', value: 'z' },
 ];
-const matcher = startsWithMatcher;
+const matcher = forwardMatcher;
 const props = { cursorPosition, items, matcher };
 
 describe('SuggestionBox', () => {

--- a/test/lib/matcher.test.ts
+++ b/test/lib/matcher.test.ts
@@ -1,4 +1,4 @@
-import { combinedMatcher, fuzzyMatcher, includesMatcher, startsWithMatcher } from '../../src/lib/matcher';
+import { forwardPartialFuzzyMatcher, fuzzyMatcher, partialMatcher, forwardMatcher } from '../../src/lib/matcher';
 
 describe('fuzzyMatcher', () => {
   describe('query に曖昧一致する items のみが返る', () => {
@@ -119,10 +119,10 @@ describe('fuzzyMatcher', () => {
   });
 });
 
-describe('startsWithMatcher', () => {
+describe('forwardMatcher', () => {
   test('query に前方一致する items のみが返る', () => {
     expect(
-      startsWithMatcher('foo', [
+      forwardMatcher('foo', [
         // マッチする
         { key: 0, element: '', searchableText: 'foo', value: '' },
         { key: 1, element: '', searchableText: 'foo bar', value: '' },
@@ -137,7 +137,7 @@ describe('startsWithMatcher', () => {
   });
   test('マッチは capital-insensitive', () => {
     expect(
-      startsWithMatcher('foo', [
+      forwardMatcher('foo', [
         { key: 0, element: '', searchableText: 'Foo', value: '' },
         { key: 1, element: '', searchableText: 'FOO', value: '' },
         { key: 2, element: '', searchableText: 'fOo', value: '' },
@@ -148,7 +148,7 @@ describe('startsWithMatcher', () => {
       { key: 2, element: '', searchableText: 'fOo', value: '' },
     ]);
     expect(
-      startsWithMatcher('FOO', [
+      forwardMatcher('FOO', [
         { key: 0, element: '', searchableText: 'Foo', value: '' },
         { key: 1, element: '', searchableText: 'FOO', value: '' },
         { key: 2, element: '', searchableText: 'fOo', value: '' },
@@ -161,10 +161,10 @@ describe('startsWithMatcher', () => {
   });
 });
 
-describe('includesMatcher', () => {
+describe('partialMatcher', () => {
   test('query に部分一致する items のみが返る', () => {
     expect(
-      includesMatcher('foo', [
+      partialMatcher('foo', [
         // マッチする
         { key: 0, element: '', searchableText: 'foo', value: '' },
         { key: 1, element: '', searchableText: 'foo bar', value: '' },
@@ -184,7 +184,7 @@ describe('includesMatcher', () => {
   });
   test('マッチは capital-insensitive', () => {
     expect(
-      includesMatcher('foo', [
+      partialMatcher('foo', [
         { key: 0, element: '', searchableText: 'Foo', value: '' },
         { key: 1, element: '', searchableText: 'FOO', value: '' },
         { key: 2, element: '', searchableText: 'fOo', value: '' },
@@ -195,7 +195,7 @@ describe('includesMatcher', () => {
       { key: 2, element: '', searchableText: 'fOo', value: '' },
     ]);
     expect(
-      includesMatcher('FOO', [
+      partialMatcher('FOO', [
         { key: 0, element: '', searchableText: 'Foo', value: '' },
         { key: 1, element: '', searchableText: 'FOO', value: '' },
         { key: 2, element: '', searchableText: 'fOo', value: '' },
@@ -208,10 +208,10 @@ describe('includesMatcher', () => {
   });
 });
 
-describe('combinedMatcher', () => {
-  test('前方一致 > 部分一致 > 曖昧検索 の順で並び替えられて返される', () => {
+describe('forwardPartialFuzzyMatcher', () => {
+  test('前方一致 > 部分一致 > 曖昧一致 の順で並び替えられて返される', () => {
     expect(
-      combinedMatcher('aaaa', [
+      forwardPartialFuzzyMatcher('aaaa', [
         // 曖昧一致する
         { key: 1, element: '', searchableText: 'aaab', value: '' },
         { key: 2, element: '', searchableText: 'aaac', value: '' },


### PR DESCRIPTION
以下の 4 つの matcher をユーザが利用できるように

- `fuzzyMatcher`
- `forwardMatcher`
- `partialMatcher`
- `forwardPartialFuzzyMatcher`

## 使い方
```js
import { registerIconSuggestion, forwardMatcher } from '/api/code/mizdra/icon-suggestion/script.js';
registerIconSuggestion({
  matcher: forwardMatcher,
});
```