### PR TITLE
クエリをアイコンとして挿入する機能の挙動を変更する

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -68,6 +68,7 @@ export const App: FunctionComponent<AppProps> = ({
 
     return suggestedIcons.map((icon) => toItem(icon, icons));
   }, [suggestPresetIcons, editorIcons, presetIcons, projectName]);
+  const [query, setQuery] = useState('');
 
   const handleSelect = useCallback(
     (item: Item<Icon>) => {
@@ -125,10 +126,9 @@ export const App: FunctionComponent<AppProps> = ({
       e.preventDefault();
       e.stopPropagation();
       setOpen(false);
-      // TODO: 真のクエリを取ってきて挿入する
-      insertText(textInput, `[query.icon]`);
+      insertText(textInput, `[${query}.icon]`);
     },
-    [open, layout, textInput],
+    [layout, open, textInput, query],
   );
 
   const handleKeydown = useCallback(
@@ -154,6 +154,7 @@ export const App: FunctionComponent<AppProps> = ({
       onSelect={handleSelect}
       onSelectNonexistent={handleSelectNonexistent}
       onClose={handleClose}
+      onInputQuery={setQuery}
       isSuggestionCloseKeyDown={isSuggestionCloseKeyDown}
     />
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -78,11 +78,6 @@ export const App: FunctionComponent<AppProps> = ({
     [projectName, textInput],
   );
 
-  const handleSelectNonexistent = useCallback(() => {
-    setOpen(false);
-    insertText(textInput, `[${query}.icon]`);
-  }, [query, textInput]);
-
   const handleClose = useCallback(() => {
     setOpen(false);
     textInput.focus();
@@ -149,7 +144,6 @@ export const App: FunctionComponent<AppProps> = ({
       cursorPosition={cursorPosition}
       matcher={matcher}
       onSelect={handleSelect}
-      onSelectNonexistent={handleSelectNonexistent}
       onClose={handleClose}
       onInputQuery={setQuery}
       isSuggestionCloseKeyDown={isSuggestionCloseKeyDown}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -78,13 +78,10 @@ export const App: FunctionComponent<AppProps> = ({
     [projectName, textInput],
   );
 
-  const handleSelectNonexistent = useCallback(
-    (query: string) => {
-      setOpen(false);
-      insertText(textInput, `[${query}.icon]`);
-    },
-    [textInput],
-  );
+  const handleSelectNonexistent = useCallback(() => {
+    setOpen(false);
+    insertText(textInput, `[${query}.icon]`);
+  }, [query, textInput]);
 
   const handleClose = useCallback(() => {
     setOpen(false);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -83,10 +83,9 @@ export const App: FunctionComponent<AppProps> = ({
     textInput.focus();
   }, [textInput]);
 
-  const handleKeydown = useCallback(
+  const handleSuggestionOpenKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (layout !== 'page') return; // エディタのあるページ以外ではキー入力を無視する
-      if (!isSuggestionOpenKeyDown(e)) return;
       e.preventDefault();
       e.stopPropagation();
 
@@ -109,7 +108,16 @@ export const App: FunctionComponent<AppProps> = ({
         setSuggestPresetIcons((suggestPresetIcons) => !suggestPresetIcons);
       }
     },
-    [cursor, defaultSuggestPresetIcons, editor, isSuggestionOpenKeyDown, open, layout, projectName, textInput],
+    [cursor, defaultSuggestPresetIcons, editor, open, layout, projectName, textInput],
+  );
+
+  const handleKeydown = useCallback(
+    (e: KeyboardEvent) => {
+      if (isSuggestionOpenKeyDown(e)) {
+        handleSuggestionOpenKeyDown(e);
+      }
+    },
+    [isSuggestionOpenKeyDown, handleSuggestionOpenKeyDown],
   );
   useDocumentEventListener('keydown', handleKeydown, { capture: true });
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,7 +14,9 @@ const DEFAULT_IS_SUGGESTION_OPEN_KEY_DOWN = (e: KeyboardEvent) => {
 };
 
 const DEFAULT_IS_INSERT_QUERY_KEY_DOWN = (e: KeyboardEvent) => {
-  return e.key === 'Enter' && !e.ctrlKey && !e.shiftKey && e.altKey && !e.metaKey;
+  if (e.key === 'Enter' && !e.ctrlKey && !e.shiftKey && e.altKey && !e.metaKey) return true;
+  if (e.key === 'Enter' && !e.ctrlKey && !e.shiftKey && !e.altKey && e.metaKey) return true;
+  return false;
 };
 
 function toItem(icon: Icon, icons: Icon[]): Item<Icon> {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,7 @@ import { useDocumentEventListener } from '../hooks/useDocumentEventListener';
 import { useScrapbox } from '../hooks/useScrapbox';
 import { uniqBy } from '../lib/collection';
 import { hasDuplicatedPageTitle, Icon } from '../lib/icon';
+import { isComposing } from '../lib/key';
 import { calcCursorPosition, insertText, scanIconsFromEditor } from '../lib/scrapbox';
 import { CursorPosition, Matcher } from '../types';
 import { SuggestionBox, Item } from './SuggestionBox';
@@ -132,6 +133,7 @@ export const App: FunctionComponent<AppProps> = ({
 
   const handleKeydown = useCallback(
     (e: KeyboardEvent) => {
+      if (isComposing(e)) return; // IMEによる変換中は何もしない
       if (isSuggestionOpenKeyDown(e)) {
         handleSuggestionOpenKeyDown(e);
       } else if (isInsertQueryKeyDown(e)) {

--- a/src/components/PopupMenu.tsx
+++ b/src/components/PopupMenu.tsx
@@ -5,6 +5,7 @@ import useResizeObserver from 'use-resize-observer';
 import { useDocumentEventListener } from '../hooks/useDocumentEventListener';
 import { useScrapbox } from '../hooks/useScrapbox';
 import { calcButtonContainerStyle, calcPopupMenuStyle, calcTriangleStyle } from '../lib/calc-style';
+import { isComposing } from '../lib/key';
 import { CursorPosition } from '../types';
 import { PopupMenuButton } from './PopupMenu/Button';
 
@@ -52,7 +53,7 @@ export function PopupMenu({
       // 閉じている時は何もしない
       if (!open) return;
       // IMEによる変換中は何もしない
-      if (e.isComposing || (e.key === 'Enter' && e.which === 229)) return;
+      if (isComposing(e)) return;
 
       const isTab = e.key === 'Tab' && !e.ctrlKey && !e.shiftKey && !e.altKey;
       const isShiftTab = e.key === 'Tab' && !e.ctrlKey && e.shiftKey && !e.altKey;

--- a/src/components/PopupMenu.tsx
+++ b/src/components/PopupMenu.tsx
@@ -21,7 +21,6 @@ export type PopupMenuProps = {
   cursorPosition: CursorPosition;
   items: Item[];
   onSelect?: (item: Item, index: number) => void;
-  onSelectNonexistent?: () => void;
   onClose?: () => void;
   isPopupCloseKeyDown?: (e: KeyboardEvent) => boolean;
 };
@@ -32,7 +31,6 @@ export function PopupMenu({
   cursorPosition,
   items,
   onSelect,
-  onSelectNonexistent,
   onClose,
   isPopupCloseKeyDown = DEFAULT_IS_POPUP_CLOSE_KEY_DOWN,
 }: PopupMenuProps) {
@@ -66,7 +64,6 @@ export function PopupMenu({
       }
 
       if (isEmpty || selectedIndex === null) {
-        if (isEnter) onSelectNonexistent?.();
         if (isClose) onClose?.();
       } else {
         if (isTab) setSelectedIndex((selectedIndex + 1) % items.length);
@@ -75,7 +72,7 @@ export function PopupMenu({
         if (isClose) onClose?.();
       }
     },
-    [isEmpty, isPopupCloseKeyDown, items, onClose, onSelect, onSelectNonexistent, open, selectedIndex],
+    [isEmpty, isPopupCloseKeyDown, items, onClose, onSelect, open, selectedIndex],
   );
   useDocumentEventListener('keydown', handleKeydown, { capture: true });
 

--- a/src/components/SuggestionBox.tsx
+++ b/src/components/SuggestionBox.tsx
@@ -20,7 +20,6 @@ export type SuggestionBoxProps<T> = {
   cursorPosition: CursorPosition;
   matcher?: Matcher<T>;
   onSelect?: (item: Item<T>) => void;
-  onSelectNonexistent?: () => void;
   onClose?: () => void;
   onInputQuery?: (query: string) => void;
   isSuggestionCloseKeyDown?: (e: KeyboardEvent) => boolean;
@@ -33,7 +32,6 @@ export function SuggestionBox<T>({
   cursorPosition,
   matcher = forwardPartialFuzzyMatcher,
   onSelect,
-  onSelectNonexistent,
   onClose,
   onInputQuery,
   isSuggestionCloseKeyDown,
@@ -59,9 +57,6 @@ export function SuggestionBox<T>({
     },
     [matchedItems, onSelect],
   );
-  const handleSelectNonexistent = useCallback(() => {
-    onSelectNonexistent?.();
-  }, [onSelectNonexistent]);
   const handleClose = useCallback(() => {
     onClose?.();
   }, [onClose]);
@@ -81,7 +76,6 @@ export function SuggestionBox<T>({
         items={matchedItemsForPopupMenu}
         cursorPosition={cursorPosition}
         onSelect={handleSelect}
-        onSelectNonexistent={handleSelectNonexistent}
         onClose={handleClose}
         isPopupCloseKeyDown={isSuggestionCloseKeyDown}
       />

--- a/src/components/SuggestionBox.tsx
+++ b/src/components/SuggestionBox.tsx
@@ -19,9 +19,9 @@ export type SuggestionBoxProps<T> = {
   items: Item<T>[];
   cursorPosition: CursorPosition;
   matcher?: Matcher<T>;
-  onSelect?: (item: Item<T>, query: string) => void;
-  onSelectNonexistent?: (query: string) => void;
-  onClose?: (query: string) => void;
+  onSelect?: (item: Item<T>) => void;
+  onSelectNonexistent?: () => void;
+  onClose?: () => void;
   onInputQuery?: (query: string) => void;
   isSuggestionCloseKeyDown?: (e: KeyboardEvent) => boolean;
 };
@@ -55,16 +55,16 @@ export function SuggestionBox<T>({
 
   const handleSelect = useCallback(
     (_item: ComponentChild, index: number) => {
-      onSelect?.(matchedItems[index], query);
+      onSelect?.(matchedItems[index]);
     },
-    [matchedItems, onSelect, query],
+    [matchedItems, onSelect],
   );
   const handleSelectNonexistent = useCallback(() => {
-    onSelectNonexistent?.(query);
-  }, [onSelectNonexistent, query]);
+    onSelectNonexistent?.();
+  }, [onSelectNonexistent]);
   const handleClose = useCallback(() => {
-    onClose?.(query);
-  }, [onClose, query]);
+    onClose?.();
+  }, [onClose]);
   const handleInputQuery = useCallback(
     (query: string) => {
       setQuery(query);

--- a/src/components/SuggestionBox.tsx
+++ b/src/components/SuggestionBox.tsx
@@ -22,6 +22,7 @@ export type SuggestionBoxProps<T> = {
   onSelect?: (item: Item<T>, query: string) => void;
   onSelectNonexistent?: (query: string) => void;
   onClose?: (query: string) => void;
+  onInputQuery?: (query: string) => void;
   isSuggestionCloseKeyDown?: (e: KeyboardEvent) => boolean;
 };
 
@@ -34,6 +35,7 @@ export function SuggestionBox<T>({
   onSelect,
   onSelectNonexistent,
   onClose,
+  onInputQuery,
   isSuggestionCloseKeyDown,
 }: SuggestionBoxProps<T>) {
   const [query, setQuery] = useState('');
@@ -63,6 +65,13 @@ export function SuggestionBox<T>({
   const handleClose = useCallback(() => {
     onClose?.(query);
   }, [onClose, query]);
+  const handleInputQuery = useCallback(
+    (query: string) => {
+      setQuery(query);
+      onInputQuery?.(query);
+    },
+    [onInputQuery],
+  );
 
   return (
     <div>
@@ -77,7 +86,12 @@ export function SuggestionBox<T>({
         isPopupCloseKeyDown={isSuggestionCloseKeyDown}
       />
       {open && (
-        <QueryInput defaultQuery={query} cursorPosition={cursorPosition} onInput={setQuery} onBlur={handleClose} />
+        <QueryInput
+          defaultQuery={query}
+          cursorPosition={cursorPosition}
+          onInput={handleInputQuery}
+          onBlur={handleClose}
+        />
       )}
     </div>
   );

--- a/src/lib/key.ts
+++ b/src/lib/key.ts
@@ -1,0 +1,4 @@
+/** IME による変換中かどうか */
+export function isComposing(e: KeyboardEvent): boolean {
+  return e.isComposing || (e.key === 'Enter' && e.which === 229);
+}

--- a/src/lib/register.tsx
+++ b/src/lib/register.tsx
@@ -53,6 +53,10 @@ type Options = {
   isSuggestionCloseKeyDown?: (e: KeyboardEvent) => boolean;
   /** @deprecated */
   isSuggestionReloadKeyDown?: (e: KeyboardEvent) => boolean;
+  /**
+   * クエリを `[query.icon]` として挿入するかどうかを判定するコールバック。キーが押下される度に呼び出される。
+   * */
+  isInsertQueryKeyDown?: (e: KeyboardEvent) => boolean;
   /** suggest に含めたいプリセットアイコンのリスト */
   presetIcons?: PresetIconsItem[];
   /**
@@ -93,6 +97,7 @@ export async function registerIconSuggestion(options?: Options) {
       <App
         isSuggestionOpenKeyDown={options?.isSuggestionOpenKeyDown}
         isSuggestionCloseKeyDown={options?.isSuggestionCloseKeyDown}
+        isInsertQueryKeyDown={options?.isInsertQueryKeyDown}
         presetIcons={presetIcons}
         defaultSuggestPresetIcons={options?.defaultSuggestPresetIcons}
         matcher={options?.matcher}

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -9,7 +9,13 @@ import { ScrapboxContext } from '../../src/contexts/ScrapboxContext';
 import { Icon } from '../../src/lib/icon';
 import { forwardMatcher } from '../../src/lib/matcher';
 import { createEditor, createScrapboxAPI } from '../helpers/html';
-import { keydownAEvent, keydownCtrlLEvent, keydownEnterEvent, keydownEscapeEvent } from '../helpers/key';
+import {
+  keydownAEvent,
+  keydownAltEnterEvent,
+  keydownCtrlLEvent,
+  keydownEnterEvent,
+  keydownEscapeEvent,
+} from '../helpers/key';
 
 jest.mock('../../src/lib/scrapbox', () => {
   return {
@@ -110,6 +116,16 @@ describe('App', () => {
         fireEvent(document, keydownCtrlLEvent);
       });
       expect(buttonContainer.childElementCount).toEqual(3); // a, b, cccc の 3アイコンが表示される
+    });
+    test('isInsertQueryKeyDown が真になるようなキーを押下したら、`[query.icon] が挿入される', async () => {
+      const { getByTestId } = await renderApp({});
+      const queryInput = getByTestId('query-input');
+
+      userEvent.type(queryInput, 'mizdra');
+      await act(() => {
+        fireEvent(document, keydownAltEnterEvent);
+      });
+      expect(mockInsertText).toBeCalledWith(expect.anything(), '[mizdra.icon]');
     });
     test('defaultSuggestPresetIcons が真なら最初からプリセットアイコンが suggest される', async () => {
       const { getByTestId } = await renderApp({ defaultSuggestPresetIcons: true });

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -87,16 +87,6 @@ describe('App', () => {
       expect(queryByTestId('popup-menu')).not.toBeInTheDocument();
     });
     describe('Enter を押下した時', () => {
-      test('アイテムが1つもなければ QueryInput に入力した pagePath のアイコンが挿入される', async () => {
-        const { getByTestId } = await renderApp({ presetIcons: [] });
-        const queryInput = getByTestId('query-input');
-        userEvent.type(queryInput, 'foo');
-        expect(queryInput).toHaveValue('foo');
-        await act(() => {
-          fireEvent(document, keydownEnterEvent);
-        });
-        expect(mockInsertText).toBeCalledWith(expect.anything(), '[foo.icon]');
-      });
       test('アイテムがあれば選択中のアイコンが挿入される', async () => {
         const { getByTestId } = await renderApp({});
         const buttonContainer = getByTestId('button-container');

--- a/test/components/PopupMenu.test.tsx
+++ b/test/components/PopupMenu.test.tsx
@@ -34,26 +34,16 @@ describe('PopupMenu', () => {
       const { queryByTestId } = render(<PopupMenu open={false} {...props} />);
       expect(queryByTestId('popup-menu')).toBeNull();
     });
-    test('Enter や Escape を押下しても、onSelect / onSelectNonexistent / onClose は呼び出されない', async () => {
+    test('Enter や Escape を押下しても、onSelect / onClose は呼び出されない', async () => {
       const onSelect = jest.fn();
-      const onSelectNonexistent = jest.fn();
       const onClose = jest.fn();
-      render(
-        <PopupMenu
-          open={false}
-          {...props}
-          onSelect={onSelect}
-          onSelectNonexistent={onSelectNonexistent}
-          onClose={onClose}
-        />,
-      );
+      render(<PopupMenu open={false} {...props} onSelect={onSelect} onClose={onClose} />);
 
       await act(() => {
         fireEvent(document, keydownEnterEvent);
         fireEvent(document, keydownEscapeEvent);
       });
       expect(onSelect).toBeCalledTimes(0);
-      expect(onSelectNonexistent).toBeCalledTimes(0);
       expect(onClose).toBeCalledTimes(0);
     });
     test('いかなるキーを押下しても、PopupMenu 側でキャンセルされない', async () => {
@@ -81,15 +71,13 @@ describe('PopupMenu', () => {
         const { getByText } = render(<PopupMenu open {...props} items={items} emptyMessage={emptyMessage} />);
         expect(getByText(emptyMessage)).toBeVisible();
       });
-      test('Enter 押下で onSelectNonexistent が呼び出される', async () => {
-        const onSelectNonexistent = jest.fn();
-        render(<PopupMenu open {...props} items={items} onSelectNonexistent={onSelectNonexistent} />);
-
-        expect(onSelectNonexistent).toBeCalledTimes(0);
+      test('Enter を押下しても onSelect は呼び出されない', async () => {
+        const onSelect = jest.fn();
+        render(<PopupMenu open {...props} items={items} onSelect={onSelect} />);
         await act(() => {
           fireEvent(document, keydownEnterEvent);
         });
-        expect(onSelectNonexistent).toBeCalledTimes(1);
+        expect(onSelect).toBeCalledTimes(0);
       });
       test('Escape 押下で onClose が呼び出される', async () => {
         const onClose = jest.fn();

--- a/test/components/SuggestBox.test.tsx
+++ b/test/components/SuggestBox.test.tsx
@@ -48,15 +48,6 @@ describe('SuggestionBox', () => {
         const { getByText } = render(<SuggestionBox open {...props} items={[]} emptyMessage={emptyMessage} />);
         expect(getByText(emptyMessage)).toBeInTheDocument();
       });
-      test('Enter 押下で onSelectNonexistent が呼び出される', async () => {
-        const onSelectNonexistent = jest.fn();
-        render(<SuggestionBox open {...props} items={[]} onSelectNonexistent={onSelectNonexistent} />);
-        expect(onSelectNonexistent).toBeCalledTimes(0);
-        await act(() => {
-          fireEvent(document, keydownEnterEvent);
-        });
-        expect(onSelectNonexistent).toBeCalledTimes(1);
-      });
     });
     describe('ポップアップに表示されるアイテムが空でない時', () => {
       test('QueryInput に文字を入力するとアイテムがフィルタされる', () => {

--- a/test/helpers/key.ts
+++ b/test/helpers/key.ts
@@ -1,4 +1,5 @@
 export const keydownEnterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+export const keydownAltEnterEvent = new KeyboardEvent('keydown', { key: 'Enter', altKey: true });
 export const keydownEscapeEvent = new KeyboardEvent('keydown', { key: 'Escape' });
 export const keydownTabEvent = new KeyboardEvent('keydown', { key: 'Tab' });
 export const keydownShiftTabEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });


### PR DESCRIPTION
close: #82 

## やったこと
- クエリをアイコンとして挿入する機能の挙動を変更
  - Before: suggest 候補が無い時に Enter 押下
  - After: Alt+Enter 押下 OR Meta+Enter 押下
- `isInsertQueryKeyDown` オプションのサポート