### PR TITLE
`defaultSuggestPresetIcons` のデフォルト値を `true` に

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -55,7 +55,7 @@ export const App: FunctionComponent<AppProps> = ({
   isSuggestionCloseKeyDown,
   isInsertQueryKeyDown = DEFAULT_IS_INSERT_QUERY_KEY_DOWN,
   presetIcons = [],
-  defaultSuggestPresetIcons = false,
+  defaultSuggestPresetIcons = true,
   matcher,
 }) => {
   const { textInput, cursor, editor, layout, projectName } = useScrapbox();

--- a/src/lib/register.tsx
+++ b/src/lib/register.tsx
@@ -62,7 +62,7 @@ type Options = {
   /**
    * ポップアップを開いた直後にプリセットアイコンを候補として表示するか。
    * `true` なら表示、`false` なら非表示。
-   * @default `false`
+   * @default true
    * */
   defaultSuggestPresetIcons?: boolean;
   /**

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -43,7 +43,7 @@ function App(props: AppProps & Options) {
   const matcher = forwardMatcher;
   return (
     <ScrapboxContext.Provider value={{ editor, scrapbox }}>
-      <NativeApp presetIcons={presetIcons} matcher={matcher} {...props} />
+      <NativeApp presetIcons={presetIcons} defaultSuggestPresetIcons={false} matcher={matcher} {...props} />
     </ScrapboxContext.Provider>
   );
 }


### PR DESCRIPTION
- 現在 `defaultSuggestPresetIcons` のデフォルト値は `false` になっている
  - `false` になっているのは、いきなり suggest 候補がプリセットアイコンまみれになると見づらくなって、嫌がられるのを防ぐため
- ただよくよく考えると `presetIcons` はちょっとずつ増やしていくものなので、いきなりプリセットアイコンまみれになることはない
- むしろ `false` になっていることで、「何故か `presetIcons` をセットしたのにアイコンが出てこない」と思われてしまうかもしれない
- それでは勿体ないのでデフォルト値を `true` にしたい