### PR TITLE
matcher からプリセットアイコンとページに埋め込まれているアイコンを区別できるように

### DIFF
--- a/src/components/SearchablePopupMenu.tsx
+++ b/src/components/SearchablePopupMenu.tsx
@@ -1,36 +1,35 @@
 import { ComponentChild } from 'preact';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { Icon } from '../lib/icon';
-import { forwardPartialFuzzyMatcher } from '../lib/matcher';
-import { CursorPosition, Matcher } from '../types';
+import { CursorPosition } from '../types';
 import { PopupMenu } from './PopupMenu';
 import { SearchInput } from './SearchablePopupMenu/SearchInput';
 
-export type SearchablePopupMenuProps<T> = {
+export type SearchablePopupMenuMatcher = (query: string) => Icon[];
+
+export type SearchablePopupMenuProps = {
   open: boolean;
   emptyMessage?: string;
-  icons: Icon[];
   cursorPosition: CursorPosition;
-  matcher?: Matcher<T>;
+  matcher: SearchablePopupMenuMatcher;
   onSelect?: (icon: Icon) => void;
   onClose?: () => void;
   onInputQuery?: (query: string) => void;
   isSuggestionCloseKeyDown?: (e: KeyboardEvent) => boolean;
 };
 
-export function SearchablePopupMenu<T>({
+export function SearchablePopupMenu({
   open,
   emptyMessage,
-  icons,
   cursorPosition,
-  matcher = forwardPartialFuzzyMatcher,
+  matcher,
   onSelect,
   onClose,
   onInputQuery,
   isSuggestionCloseKeyDown,
-}: SearchablePopupMenuProps<T>) {
+}: SearchablePopupMenuProps) {
   const [query, setQuery] = useState('');
-  const matchedIcons = useMemo(() => matcher(query, icons), [icons, matcher, query]);
+  const matchedIcons = useMemo(() => matcher(query), [matcher, query]);
 
   useEffect(() => {
     if (open === false) setQuery('');

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -5,9 +5,9 @@ import { Icon } from './icon';
 
 /**
  * 曖昧一致による matcher。
- * 曖昧一致で `icons` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
+ * 曖昧一致で `composedIcons` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
-export function fuzzyMatcher({ query, icons }: MatcherOptions): Icon[] {
+export function fuzzyMatcher({ query, composedIcons }: MatcherOptions): Icon[] {
   // query の長さが 0〜2 なら 0 文字まで、3〜5 なら 1 文字まで、
   // 6〜8 なら 2 文字まで、9 以上なら 3 文字まで誤字を許容する
   const maxAambig = Math.min(Math.floor(query.length / 3), 3);
@@ -15,7 +15,7 @@ export function fuzzyMatcher({ query, icons }: MatcherOptions): Icon[] {
   // あいまい度の少ない項目から順に並べる
   const newIcons: Icon[] = [];
   for (let ambig = 0; ambig <= maxAambig; ambig++) {
-    for (const icon of icons) {
+    for (const icon of composedIcons) {
       if (match(icon.pageTitle, ambig)) newIcons.push(icon);
     }
   }
@@ -26,18 +26,18 @@ export function fuzzyMatcher({ query, icons }: MatcherOptions): Icon[] {
 
 /**
  * 前方一致による matcher。
- * 元の `icons` の順序を維持しつつ、`icons` を前方一致でフィルタして返す。
+ * 元の `composedIcons` の順序を維持しつつ、`composedIcons` を前方一致でフィルタして返す。
  * */
-export function forwardMatcher({ query, icons }: MatcherOptions): Icon[] {
-  return icons.filter((icon) => icon.pageTitle.toLowerCase().startsWith(query.toLowerCase()));
+export function forwardMatcher({ query, composedIcons }: MatcherOptions): Icon[] {
+  return composedIcons.filter((icon) => icon.pageTitle.toLowerCase().startsWith(query.toLowerCase()));
 }
 
 /**
  * 部分一致による matcher。
- * 元の `icons` の順序を維持しつつ、`icons` を部分一致でフィルタして返す。
+ * 元の `composedIcons` の順序を維持しつつ、`composedIcons` を部分一致でフィルタして返す。
  * */
-export function partialMatcher({ query, icons }: MatcherOptions): Icon[] {
-  return icons.filter((icon) => icon.pageTitle.toLowerCase().includes(query.toLowerCase()));
+export function partialMatcher({ query, composedIcons }: MatcherOptions): Icon[] {
+  return composedIcons.filter((icon) => icon.pageTitle.toLowerCase().includes(query.toLowerCase()));
 }
 
 /**

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -1,4 +1,5 @@
 import Asearch from 'asearch';
+import { MatcherOptions } from '../types';
 import { uniqBy } from './collection';
 import { Icon } from './icon';
 
@@ -6,7 +7,7 @@ import { Icon } from './icon';
  * 曖昧一致による matcher。
  * 曖昧一致で `icons` をフィルタしつつ、編集距離の昇順で並べ替えて返す。
  */
-export function fuzzyMatcher(query: string, icons: Icon[]): Icon[] {
+export function fuzzyMatcher({ query, icons }: MatcherOptions): Icon[] {
   // query の長さが 0〜2 なら 0 文字まで、3〜5 なら 1 文字まで、
   // 6〜8 なら 2 文字まで、9 以上なら 3 文字まで誤字を許容する
   const maxAambig = Math.min(Math.floor(query.length / 3), 3);
@@ -27,7 +28,7 @@ export function fuzzyMatcher(query: string, icons: Icon[]): Icon[] {
  * 前方一致による matcher。
  * 元の `icons` の順序を維持しつつ、`icons` を前方一致でフィルタして返す。
  * */
-export function forwardMatcher(query: string, icons: Icon[]): Icon[] {
+export function forwardMatcher({ query, icons }: MatcherOptions): Icon[] {
   return icons.filter((icon) => icon.pageTitle.toLowerCase().startsWith(query.toLowerCase()));
 }
 
@@ -35,7 +36,7 @@ export function forwardMatcher(query: string, icons: Icon[]): Icon[] {
  * 部分一致による matcher。
  * 元の `icons` の順序を維持しつつ、`icons` を部分一致でフィルタして返す。
  * */
-export function partialMatcher(query: string, icons: Icon[]): Icon[] {
+export function partialMatcher({ query, icons }: MatcherOptions): Icon[] {
   return icons.filter((icon) => icon.pageTitle.toLowerCase().includes(query.toLowerCase()));
 }
 
@@ -43,8 +44,8 @@ export function partialMatcher(query: string, icons: Icon[]): Icon[] {
  * 前方一致、部分一致、曖昧一致を組み合わせた matcher。
  * 前方一致 > 部分一致 > 曖昧一致 の順で fallback しながらフィルタしていき、残ったものを返す。
  * */
-export function forwardPartialFuzzyMatcher(query: string, icons: Icon[]): Icon[] {
-  const newIcons = [...forwardMatcher(query, icons), ...partialMatcher(query, icons), ...fuzzyMatcher(query, icons)];
+export function forwardPartialFuzzyMatcher(options: MatcherOptions): Icon[] {
+  const newIcons = [...forwardMatcher(options), ...partialMatcher(options), ...fuzzyMatcher(options)];
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return uniqBy(newIcons, (icon) => icon.fullPagePath);
 }

--- a/src/lib/register.tsx
+++ b/src/lib/register.tsx
@@ -3,7 +3,6 @@ import { App } from '../components/App';
 import { evaluatePresetIconItemsToIcons } from '../lib/options';
 import { getEditor } from '../lib/scrapbox';
 import { Matcher, PresetIconsItem } from '../types';
-import { Icon } from './icon';
 
 type Options = {
   /**
@@ -31,7 +30,7 @@ type Options = {
   /**
    * suggest されたアイコンを絞り込むために利用される matcher。
    */
-  matcher?: Matcher<Icon>;
+  matcher?: Matcher;
   scrapbox?: Scrapbox;
   editor?: HTMLElement;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,5 +31,20 @@ export type Item<T> = {
   value: T;
 };
 
+/** matcher に渡すオプションの型 */
+export type MatcherOptions = {
+  /** 検索欄に入力された文字列 */
+  query: string;
+  /**
+   * `suggestPresetIcons` が真の時は `[...presetIcons, ...embeddedIcons]` を、
+   * 偽の時は `embeddedIcons` を表すアイコンリスト。
+   * */
+  icons: Icon[];
+  /** プリセットアイコンのリスト */
+  presetIcons: Icon[];
+  /** ページに埋め込まれているアイコンのリスト */
+  embeddedIcons: Icon[];
+};
+
 /** SearchablePopupMenu 内でアイテムのフィルタに利用される matcher の型 */
-export type Matcher<T> = (query: string, icons: Icon[]) => Icon[];
+export type Matcher = (options: MatcherOptions) => Icon[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type MatcherOptions = {
    * `suggestPresetIcons` が真の時は `[...presetIcons, ...embeddedIcons]` を、
    * 偽の時は `embeddedIcons` を表すアイコンリスト。
    * */
-  icons: Icon[];
+  composedIcons: Icon[];
   /** プリセットアイコンのリスト */
   presetIcons: Icon[];
   /** ページに埋め込まれているアイコンのリスト */

--- a/test/components/SearchablePopupMenu.test.tsx
+++ b/test/components/SearchablePopupMenu.test.tsx
@@ -15,8 +15,8 @@ const icons = [
   new Icon('project', 'abc'),
   new Icon('project', 'z'),
 ];
-const matcher = forwardMatcher;
-const props = { cursorPosition, icons, matcher };
+const matcher = (query: string) => forwardMatcher({ query, composedIcons: icons, embeddedIcons: [], presetIcons: [] });
+const props = { cursorPosition, matcher };
 
 describe('SearchablePopupMenu', () => {
   describe('open === false の時', () => {
@@ -46,7 +46,9 @@ describe('SearchablePopupMenu', () => {
     describe('ポップアップに表示されるアイテムが空の時', () => {
       test('emptyMessage でアイテムが空の時のメッセージを変更できる', () => {
         const emptyMessage = datatype.string();
-        const { getByText } = render(<SearchablePopupMenu open {...props} icons={[]} emptyMessage={emptyMessage} />);
+        const { getByText } = render(
+          <SearchablePopupMenu open {...props} matcher={() => []} emptyMessage={emptyMessage} />,
+        );
         expect(getByText(emptyMessage)).toBeInTheDocument();
       });
     });

--- a/test/lib/matcher.test.ts
+++ b/test/lib/matcher.test.ts
@@ -1,52 +1,70 @@
 import { Icon } from '../../src/lib/icon';
 import { forwardPartialFuzzyMatcher, fuzzyMatcher, partialMatcher, forwardMatcher } from '../../src/lib/matcher';
 
+const args = { presetIcons: [], embeddedIcons: [] };
+
 describe('fuzzyMatcher', () => {
   describe('query に曖昧一致する icons のみが返る', () => {
     test('query の長さが 0〜2 なら 1 文字も誤字を許容しない', () => {
       expect(
-        fuzzyMatcher('aa', [
-          // マッチする
-          new Icon('project', 'aa'),
-          // マッチしない
-          new Icon('project', 'ab'),
-        ]),
+        fuzzyMatcher({
+          ...args,
+          query: 'aa',
+          composedIcons: [
+            // マッチする
+            new Icon('project', 'aa'),
+            // マッチしない
+            new Icon('project', 'ab'),
+          ],
+        }),
       ).toStrictEqual([new Icon('project', 'aa')]);
     });
     test('query の長さが 3〜5 なら 1 文字まで誤字を許容する', () => {
       expect(
-        fuzzyMatcher('aaa', [
-          // マッチする
-          new Icon('project', 'aaa'),
-          new Icon('project', 'aab'),
-          // マッチしない
-          new Icon('project', 'abb'),
-        ]),
+        fuzzyMatcher({
+          ...args,
+          query: 'aaa',
+          composedIcons: [
+            // マッチする
+            new Icon('project', 'aaa'),
+            new Icon('project', 'aab'),
+            // マッチしない
+            new Icon('project', 'abb'),
+          ],
+        }),
       ).toStrictEqual([new Icon('project', 'aaa'), new Icon('project', 'aab')]);
     });
     test('query の長さが 6〜8 なら 2 文字まで誤字を許容する', () => {
       expect(
-        fuzzyMatcher('aaaaaa', [
-          // マッチする
-          new Icon('project', 'aaaaaa'),
-          new Icon('project', 'aaaaab'),
-          new Icon('project', 'aaaabb'),
-          // マッチしない
-          new Icon('project', 'aaabbb'),
-        ]),
+        fuzzyMatcher({
+          ...args,
+          query: 'aaaaaa',
+          composedIcons: [
+            // マッチする
+            new Icon('project', 'aaaaaa'),
+            new Icon('project', 'aaaaab'),
+            new Icon('project', 'aaaabb'),
+            // マッチしない
+            new Icon('project', 'aaabbb'),
+          ],
+        }),
       ).toStrictEqual([new Icon('project', 'aaaaaa'), new Icon('project', 'aaaaab'), new Icon('project', 'aaaabb')]);
     });
     test('query の長さが 9 以上なら 3 文字まで誤字を許容する', () => {
       expect(
-        fuzzyMatcher('aaaaaaaaa', [
-          // マッチする
-          new Icon('project', 'aaaaaaaaa'),
-          new Icon('project', 'aaaaaaaab'),
-          new Icon('project', 'aaaaaaabb'),
-          new Icon('project', 'aaaaaabbb'),
-          // マッチしない
-          new Icon('project', 'aaaaabbbb'),
-        ]),
+        fuzzyMatcher({
+          ...args,
+          query: 'aaaaaaaaa',
+          composedIcons: [
+            // マッチする
+            new Icon('project', 'aaaaaaaaa'),
+            new Icon('project', 'aaaaaaaab'),
+            new Icon('project', 'aaaaaaabb'),
+            new Icon('project', 'aaaaaabbb'),
+            // マッチしない
+            new Icon('project', 'aaaaabbbb'),
+          ],
+        }),
       ).toStrictEqual([
         new Icon('project', 'aaaaaaaaa'),
         new Icon('project', 'aaaaaaaab'),
@@ -57,15 +75,19 @@ describe('fuzzyMatcher', () => {
   });
   describe('曖昧度の昇順で返ってくる', () => {
     expect(
-      fuzzyMatcher('aaaaaaaaaaaa', [
-        new Icon('project', 'aaaaaaaaabbb'),
-        new Icon('project', 'aaaaaaaaaccc'),
-        new Icon('project', 'aaaaaaaaaabb'),
-        new Icon('project', 'aaaaaaaaaacc'),
-        new Icon('project', 'aaaaaaaaaaab'),
-        new Icon('project', 'aaaaaaaaaaac'),
-        new Icon('project', 'aaaaaaaaaaaa'),
-      ]),
+      fuzzyMatcher({
+        ...args,
+        query: 'aaaaaaaaaaaa',
+        composedIcons: [
+          new Icon('project', 'aaaaaaaaabbb'),
+          new Icon('project', 'aaaaaaaaaccc'),
+          new Icon('project', 'aaaaaaaaaabb'),
+          new Icon('project', 'aaaaaaaaaacc'),
+          new Icon('project', 'aaaaaaaaaaab'),
+          new Icon('project', 'aaaaaaaaaaac'),
+          new Icon('project', 'aaaaaaaaaaaa'),
+        ],
+      }),
     ).toStrictEqual([
       new Icon('project', 'aaaaaaaaaaaa'),
       new Icon('project', 'aaaaaaaaaaab'),
@@ -77,17 +99,28 @@ describe('fuzzyMatcher', () => {
     ]);
   });
   describe('部分一致する', () => {
-    expect(fuzzyMatcher('foo', [new Icon('project', 'foo bar'), new Icon('project', 'bar foo baz')])).toStrictEqual([
-      new Icon('project', 'foo bar'),
-      new Icon('project', 'bar foo baz'),
-    ]);
+    expect(
+      fuzzyMatcher({
+        ...args,
+        query: 'foo',
+        composedIcons: [new Icon('project', 'foo bar'), new Icon('project', 'bar foo baz')],
+      }),
+    ).toStrictEqual([new Icon('project', 'foo bar'), new Icon('project', 'bar foo baz')]);
   });
   test('マッチは capital-insensitive', () => {
     expect(
-      fuzzyMatcher('foo', [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]),
+      fuzzyMatcher({
+        ...args,
+        query: 'foo',
+        composedIcons: [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')],
+      }),
     ).toStrictEqual([new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]);
     expect(
-      fuzzyMatcher('FOO', [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]),
+      fuzzyMatcher({
+        ...args,
+        query: 'FOO',
+        composedIcons: [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')],
+      }),
     ).toStrictEqual([new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]);
   });
 });
@@ -95,22 +128,34 @@ describe('fuzzyMatcher', () => {
 describe('forwardMatcher', () => {
   test('query に前方一致する icons のみが返る', () => {
     expect(
-      forwardMatcher('foo', [
-        // マッチする
-        new Icon('project', 'foo'),
-        new Icon('project', 'foo bar'),
-        // マッチしない
-        new Icon('project', 'bar foo'),
-        new Icon('project', 'fo bar'),
-      ]),
+      forwardMatcher({
+        ...args,
+        query: 'foo',
+        composedIcons: [
+          // マッチする
+          new Icon('project', 'foo'),
+          new Icon('project', 'foo bar'),
+          // マッチしない
+          new Icon('project', 'bar foo'),
+          new Icon('project', 'fo bar'),
+        ],
+      }),
     ).toStrictEqual([new Icon('project', 'foo'), new Icon('project', 'foo bar')]);
   });
   test('マッチは capital-insensitive', () => {
     expect(
-      forwardMatcher('foo', [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]),
+      forwardMatcher({
+        ...args,
+        query: 'foo',
+        composedIcons: [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')],
+      }),
     ).toStrictEqual([new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]);
     expect(
-      forwardMatcher('FOO', [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]),
+      forwardMatcher({
+        ...args,
+        query: 'FOO',
+        composedIcons: [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')],
+      }),
     ).toStrictEqual([new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]);
   });
 });
@@ -118,16 +163,20 @@ describe('forwardMatcher', () => {
 describe('partialMatcher', () => {
   test('query に部分一致する icons のみが返る', () => {
     expect(
-      partialMatcher('foo', [
-        // マッチする
-        new Icon('project', 'foo'),
-        new Icon('project', 'foo bar'),
-        new Icon('project', 'foo bar baz'),
-        new Icon('project', 'bar foo baz'),
-        new Icon('project', 'bar baz foo'),
-        // マッチしない
-        new Icon('project', 'fo bar'),
-      ]),
+      partialMatcher({
+        ...args,
+        query: 'foo',
+        composedIcons: [
+          // マッチする
+          new Icon('project', 'foo'),
+          new Icon('project', 'foo bar'),
+          new Icon('project', 'foo bar baz'),
+          new Icon('project', 'bar foo baz'),
+          new Icon('project', 'bar baz foo'),
+          // マッチしない
+          new Icon('project', 'fo bar'),
+        ],
+      }),
     ).toStrictEqual([
       new Icon('project', 'foo'),
       new Icon('project', 'foo bar'),
@@ -138,10 +187,18 @@ describe('partialMatcher', () => {
   });
   test('マッチは capital-insensitive', () => {
     expect(
-      partialMatcher('foo', [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]),
+      partialMatcher({
+        ...args,
+        query: 'foo',
+        composedIcons: [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')],
+      }),
     ).toStrictEqual([new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]);
     expect(
-      partialMatcher('FOO', [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]),
+      partialMatcher({
+        ...args,
+        query: 'FOO',
+        composedIcons: [new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')],
+      }),
     ).toStrictEqual([new Icon('project', 'Foo'), new Icon('project', 'FOO'), new Icon('project', 'fOo')]);
   });
 });
@@ -149,19 +206,23 @@ describe('partialMatcher', () => {
 describe('forwardPartialFuzzyMatcher', () => {
   test('前方一致 > 部分一致 > 曖昧一致 の順で並び替えられて返される', () => {
     expect(
-      forwardPartialFuzzyMatcher('aaaa', [
-        // 曖昧一致する
-        new Icon('project', 'aaab'),
-        new Icon('project', 'aaac'),
-        // 部分一致する
-        new Icon('project', 'bbbb aaaa cccc'),
-        new Icon('project', 'bbbb cccc aaaa'),
-        // 前方一致する
-        new Icon('project', 'aaaa'),
-        new Icon('project', 'aaaa bbbb'),
-        // マッチしない
-        new Icon('project', 'mizdra'),
-      ]),
+      forwardPartialFuzzyMatcher({
+        ...args,
+        query: 'aaaa',
+        composedIcons: [
+          // 曖昧一致する
+          new Icon('project', 'aaab'),
+          new Icon('project', 'aaac'),
+          // 部分一致する
+          new Icon('project', 'bbbb aaaa cccc'),
+          new Icon('project', 'bbbb cccc aaaa'),
+          // 前方一致する
+          new Icon('project', 'aaaa'),
+          new Icon('project', 'aaaa bbbb'),
+          // マッチしない
+          new Icon('project', 'mizdra'),
+        ],
+      }),
     ).toStrictEqual([
       new Icon('project', 'aaaa'),
       new Icon('project', 'aaaa bbbb'),


### PR DESCRIPTION
close: https://github.com/mizdra/scrapbox-userscript-icon-suggestion/issues/89