### PR TITLE
エディタの横幅をはみ出る行でフォーカス位置がおかしくなる問題を修正

### DIFF
--- a/src/hooks/useScrapbox.ts
+++ b/src/hooks/useScrapbox.ts
@@ -136,8 +136,23 @@ export function useScrapbox(): Scrapbox {
   };
 }
 
-function focusEditor(element: HTMLElement, clientX: number, clientY: number) {
+/**
+ * 指定した位置にカーソルをフォーカスする。
+ * @param x フォーカスする位置の x 座標 (layout viewport の左端からの距離)
+ * @param y フォーカスする位置の y 座標 (layout viewport の上端からの距離)
+ */
+function focusEditor(pointerEvent: HTMLElement, x: number, y: number) {
+  const eventInitDict = {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    // clientX, clientY は仕様上は viewport の左上からの相対座標とされているが、
+    // 実際には、layout viewport の左上からの相対座標にスクロール量を加算したものである。
+    // そこで、スクロール量を加算して clientX, clientY を計算する。
+    clientX: window.scrollX + x,
+    clientY: window.scrollY + y,
+  };
   // mousedown イベントだけだと 範囲選択モードになってしまうため、mouseup イベントも dispatch する
-  element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0, clientX, clientY }));
-  element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, button: 0, clientX, clientY }));
+  pointerEvent.dispatchEvent(new MouseEvent('mousedown', eventInitDict));
+  pointerEvent.dispatchEvent(new MouseEvent('mouseup', eventInitDict));
 }


### PR DESCRIPTION
## 概要

- 表を使うとエディタの横幅をはみ出る行を作り出せる
- そのような行の末尾にフォーカスを当てると、画面全体が右側へとスクロールする
  - `window.scrollX > 0` となる
- このせいで ComboBox を閉じた時にフォーカスされる位置がおかしくなる問題があった

## 不具合の再現方法

1. 横に長い表を作る
2. その表の行で icon-suggestion を起動
3. Escape で icon-suggestion を閉じる

本来と異なる位置にフォーカスされてしまう。

https://github.com/user-attachments/assets/82f24066-b63a-4545-9d4c-9ec7955fe07b

## 修正後

https://github.com/user-attachments/assets/8423d0b7-7ef6-4879-a54f-6422e8975c11

